### PR TITLE
Fix settings parsing, ReplicateLayoutDialog.on_ok(), Replicator.replicate_layout()

### DIFF
--- a/action_replicate_layout.py
+++ b/action_replicate_layout.py
@@ -166,7 +166,9 @@ class ReplicateLayoutDialog(ReplicateLayoutGUI):
                             rep_text=self.chkbox_text.GetValue(), rep_drawings=self.chkbox_drawings.GetValue(),
                             rep_locked_tracks=self.chkbox_locked_tracks.GetValue(), rep_locked_zones=self.chkbox_locked_zones.GetValue(),
                             rep_locked_text=self.chkbox_locked_text.GetValue(), rep_locked_drawings=self.chkbox_locked_drawings.GetValue(),
-                            containing=not self.chkbox_intersecting.GetValue() )
+                            intersecting=self.chkbox_intersecting.GetValue(), group_items=self.chkbox_include_group_items.GetValue(),
+                            group_only=self.chkbox_group.GetValue(), locked_fps=self.chkbox_locked.GetValue(),
+                            remove=self.chkbox_remove.GetValue())
 
         # failsafe sometimes on my machine wx does not generate a listbox event
         level = self.list_levels.GetSelection()
@@ -197,12 +199,8 @@ class ReplicateLayoutDialog(ReplicateLayoutGUI):
             self.replicator.update_progress = self.update_progress
             self.replicator.replicate_layout(self.src_anchor_fp, self.src_anchor_fp.sheet_id[0:level + 1],
                                              dst_sheets,
-                                             settings,
-                                             remove=remove_existing_nets_zones,
-                                             rm_duplicates=remove_duplicates,
-                                             rep_locked_footprints=rep_locked,
-                                             by_group=group_only)
-
+                                             settings, remove_duplicates)
+                                             
             self.logger.info("Replication complete")
             # clear highlight on all footprints on selected level
             self.replicator.highlight_clear_level(self.hl_fps, self.hl_items)

--- a/replicate_layout.py
+++ b/replicate_layout.py
@@ -235,7 +235,7 @@ class Replicator:
             logger.info("Removing tracks and zones, before footprint placement")
             self.stage = 2
             self.update_progress(self.stage, 0.0, "Removing zones and tracks")
-            self.remove_zones_tracks(settings.containing)
+            self.remove_zones_tracks(settings.remove)
         self.stage = 3
         self.update_progress(self.stage, 0.0, "Replicating footprints")
         self.replicate_footprints()
@@ -243,7 +243,7 @@ class Replicator:
             logger.info("Removing tracks and zones, after footprint placement")
             self.stage = 4
             self.update_progress(self.stage, 0.0, "Removing zones and tracks")
-            self.remove_zones_tracks(settings.containing)
+            self.remove_zones_tracks(settings.remove)
         if settings.rep_tracks:
             self.stage = 5
             self.update_progress(self.stage, 0.0, "Replicating tracks")


### PR DESCRIPTION
I noticed the ReplicateLayout plugin v1.2.4 wasn't working on a fresh install of KiCad 6.09-1.fc36 (Fedora 36), installed via  KiCad Plugin and Content Manager. Using Python 3.10.8.

Clicking "Ok" on the ReplicateLayout dialog after selecting the anchor footprint did not give any response or do the desired replication. The following error was produced, visible when running KiCad in terminal:

`Traceback (most recent call last):
  File "/home/XXXX/.local/share/kicad/6.0/3rdparty/plugins/com_github_MitjaNemec_ReplicateLayout/action_replicate_layout.py", line 165, in on_ok
    settings = Settings(rep_tracks=self.chkbox_tracks.GetValue(), rep_zones=self.chkbox_zones.GetValue(),
TypeError: Settings.__new__() got an unexpected keyword argument 'containing'`

I see there was some refactoring happening with Settings in 85d4320858d1b5c87bf888f8dc08ad3593896d0b and it looks like ReplicateLayoutDialog.on_ok() and Replicator.replicate_layout() reference the old Settings.

This PR updates those functions to reflect the new Settings and fixes the error on my machine.