### PR TITLE
Change lstrip to replace (lstrip produce bug). 

### DIFF
--- a/action_replicate_layout.py
+++ b/action_replicate_layout.py
@@ -374,7 +374,7 @@ class ReplicateLayout(pcbnew.ActionPlugin):
             return
 
         src_anchor_fp = replicator.get_fp_by_ref(src_anchor_fp_reference)
-
+        
         # check if source anchor footprint is on root level
         if len(src_anchor_fp.filename) == 0:
             caption = 'Replicate layout'
@@ -385,9 +385,10 @@ class ReplicateLayout(pcbnew.ActionPlugin):
             return
 
         # check if there are at least two sheets pointing to same hierarchical file that the source anchor footprint belongs to
-        count = 0
-        for filename in replicator.dict_of_sheets.values():
-            if filename in src_anchor_fp.filename:
+        count = 0        
+        for filename in replicator.dict_of_sheets.values():           
+            # filename contain sheet name and sheet filename, check only sheet filename.
+            if filename[1] in src_anchor_fp.filename:
                 count = count + 1
         if count < 2:
             caption = 'Replicate layout'

--- a/replicate_layout.py
+++ b/replicate_layout.py
@@ -148,11 +148,11 @@ class Replicator:
         if len(unique_sheet_ids) > len(self.dict_of_sheets):
             # open root schematics file and parse for other schematics files
             # This might be prone to errors regarding path discovery
-            # thus it is used only in corner cases
+            # thus it is used only in corner cases            
             schematic_found = {}
             self.parse_schematic_files(self.sch_filename, schematic_found)
             self.dict_of_sheets = schematic_found
-
+            
         # construct a list of all the footprints
         for fp in footprints:
             try:
@@ -187,12 +187,12 @@ class Replicator:
                 sheet_id = ""
                 for j in range(i,i+10):
                     if "(uuid " in contents[j]:
-                        sheet_id = contents[j].lstrip("(uuid ").rstrip(")")
+                        sheet_id = contents[j].replace("(uuid ",'').rstrip(")").upper().strip()
                     if "(property \"Sheet name\"" in contents[j]:
-                        sheetname = contents[j].lstrip("(property \"Sheet name\"").split()[0].replace("\"", "")
+                        sheetname = contents[j].replace("(property \"Sheet name\"",'').split()[0].replace("\"", "")
                     if "(property \"Sheet file\"" in contents[j]:
-                        sheetfile = contents[j].lstrip("(property \"Sheet file\"").split()[0].replace("\"", "")
-                # here I should find all sheet data
+                        sheetfile = contents[j].replace("(property \"Sheet file\"",'').split()[0].replace("\"", "")
+                # here I should find all sheet data                
                 dict_of_sheets[sheet_id] = [sheetname, sheetfile]
                 # open a newfound file and look for nested sheets
                 self.parse_schematic_files(sheetfile, dict_of_sheets)
@@ -305,7 +305,7 @@ class Replicator:
         self.src_drawings = self.get_drawings_for_replication(self.src_bounding_box, settings)
 
     @staticmethod
-    def get_footprint_id(footprint):
+    def get_footprint_id(footprint):               
         path = footprint.GetPath().AsString().upper().replace('00000000-0000-0000-0000-0000', '').split("/")
         if len(path) != 1:
             fp_id = path[-1]
@@ -954,21 +954,23 @@ class Replicator:
             net_pairs, net_dict = self.get_net_pairs(sheet)
             # go through all the zones
             nr_zones = len(self.src_zones)
-            for zone_index in range(nr_zones):
+            for zone_index in range(nr_zones):                
                 zone = self.src_zones[zone_index]
-
+                
                 progress = progress + (1 / nr_sheets) * (1 / nr_zones)
                 self.update_progress(self.stage, progress, None)
 
                 # get from which net we are cloning
-                from_net_name = zone.GetNetname()
+                from_net_name = zone.GetNetname()                
                 # if zone is not on copper layer it does not matter on which net it is
-                if not zone.IsOnCopperLayer():
+                if not zone.IsOnCopperLayer():                    
                     tup = [('', '')]
-                else:
-                    if from_net_name:
-                        tup = [item for item in net_pairs if item[0] == from_net_name]
-                    else:
+                else:                    
+                    if from_net_name:                     
+                        tup = [item for item in net_pairs if item[0] == from_net_name]                        
+                        if len(tup) == 0:
+                            tup = [('', '')]                                                   
+                    else:                        
                         tup = [('', '')]
 
                 # there is no net
@@ -976,7 +978,7 @@ class Replicator:
                     # Allow keepout zones to be cloned.
                     if not zone.IsOnCopperLayer():
                         tup = [('', '')]
-
+                
                 # start the clone
                 to_net_name = tup[0][1]
                 if to_net_name == u'':


### PR DESCRIPTION
Hi, i have project with a lot of hierarchical sheets, and found that current version of ReplicateLayout not work propelrly. I made some changes, with them ReplicateLayout is working on my project. 
Change lstrip to replace (lstrip produce bug, for example if sheet name is power, lstrip("(property \"Sheet name\"") return "wer"). Use upper function in. sheet_id (sometimes sheet_id is not uppercase). And check only sheet filename for searching duplicate footprint.