### PR TITLE
Duplicate tracks, vias, zones, drawings in v7

### DIFF
--- a/replicate_layout.py
+++ b/replicate_layout.py
@@ -81,6 +81,21 @@ def flipped_angle(angle):
         return -180 - angle
 
 
+og_Duplicate = pcbnew.BOARD_ITEM.Duplicate
+def Duplicate7(aBoardItem):
+    ''' KiCad 7 has a bug where Duplicate always returns BOARD_ITEM
+        instead of the type of the caller, so this function includes a cast.
+    '''
+    dup = og_Duplicate(aBoardItem)
+    caster_attr = 'Cast_to_' + type(aBoardItem).__name__
+    try:
+        caster_fun = getattr(pcbnew, caster_attr)
+    except AttributeError:  # This might hit in v5 and some versions of v6
+        return dup
+    else:
+        return caster_fun(dup)
+pcbnew.BOARD_ITEM.Duplicate = Duplicate7  # Monkey patch. The alternative is changing code below
+
 class Replicator:
     def __init__(self, board, src_anchor_fp_ref, update_func=update_progress):
         self.board = board


### PR DESCRIPTION
My group has used replicate layout for years, so it was a *serious* problem when we upgraded to KiCad v7 and lost replication, which is way more valuable to us than anything introduced in the v6 -> v7 upgrade.

Turns out `PCB_ITEM.Duplicate` is returning a parent class, even if called by a via or track object. But now there are also `pcbnew.Cast_to_<insert class>` functions. It just needs a cast. I implemented with a try/catch that doesn't break v6.

Addresses #53 #52 #51 #49 

```
Version: 7.0.2-6a45011f42~172~ubuntu22.04.1, release build
Platform: Ubuntu 22.04.2 LTS, 64 bit, Little endian, wxGTK, ubuntu, x11
```
