### PR TITLE
KiCAD 9 compatibility

### DIFF
--- a/action_replicate_layout.py
+++ b/action_replicate_layout.py
@@ -413,7 +413,7 @@ class ReplicateLayout(pcbnew.ActionPlugin):
 
         # search for the Replicate.Layout user layer where replication rooms can be defined
 
-        if 'Replicate.Layout' in [board.GetLayerName(x) for x in board.GetEnabledLayers().Users()]:
+        if 'Replicate.Layout' in [board.GetLayerName(x) for x in board.GetEnabledLayers().Seq()]:
             pass
 
         # prepare the replicator

--- a/replicate_layout.py
+++ b/replicate_layout.py
@@ -922,7 +922,7 @@ class Replicator:
                 dst_fp.fp.SetLocalSolderMaskMargin(src_fp.fp.GetLocalSolderMaskMargin())
                 dst_fp.fp.SetLocalSolderPasteMargin(src_fp.fp.GetLocalSolderPasteMargin())
                 dst_fp.fp.SetLocalSolderPasteMarginRatio(src_fp.fp.GetLocalSolderPasteMarginRatio())
-                dst_fp.fp.SetZoneConnection(src_fp.fp.GetZoneConnection())
+                dst_fp.fp.SetLocalZoneConnection(src_fp.fp.GetLocalZoneConnection())
 
                 # add footprints to corresponding layout groups if selected
                 # and if footprint is not already member of this group


### PR DESCRIPTION
Fixes the change in API in KiCAD 9.
This runs on the following KiCAD version:

```
Application: KiCad PCB Editor x64 on x64

Version: 9.0.0-rc2-142-g42b9a9604b, release build

Libraries:
	wxWidgets 3.2.6
	FreeType 2.13.3
	HarfBuzz 10.0.1
	FontConfig 2.15.0
	libcurl/8.10.1-DEV Schannel zlib/1.3.1

Platform: Windows 11 (build 22631), 64-bit edition, 64 bit, Little endian, wxMSW
OpenGL: ATI Technologies Inc., AMD Radeon RX 6700 XT, 4.6.0 Compatibility Profile Context 21.10.34.230823

Build Info:
	Date: Jan 26 2025 06:17:17
	wxWidgets: 3.2.6 (wchar_t,wx containers)
	Boost: 1.86.0
	OCC: 7.8.1
	Curl: 8.10.1-DEV
	ngspice: 44
	Compiler: Visual C++ 1942 without C++ ABI
	KICAD_IPC_API=ON

Locale: 
	Lang: en_GB
	Enc: UTF-8
	Num: 1,234.5
	Encoded кΩ丈: D0BACEA9E4B888 (sys), D0BACEA9E4B888 (utf8)
```

![image](https://github.com/user-attachments/assets/52fe216d-cc30-4733-98f7-22e213f645db)

And gives this result (I'm not familiar enough with the pluging to know if that's expected or not):

![image](https://github.com/user-attachments/assets/59529b49-492d-4f27-9ae8-d809e44950f0)

